### PR TITLE
Add support for Ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,15 @@
 source 'https://rubygems.org'
 
-ruby '2.1.1'
-
 gem 'confluence-soap', '0.0.10'
 gem 'markdown2confluence', '0.0.4'
+
+if RUBY_VERSION.to_f < 2.3
+  gem 'nokogiri', '< 1.6.8'
+else
+  gem 'nokogiri'
+end
+if RUBY_VERSION.to_f < 2.2
+  gem 'rack', '< 2'
+else
+  gem 'rack'
+end


### PR DESCRIPTION
There seemed no reason to lock the Ruby version on 2.1.1, so that
restriction is removed from Gemfile.

Also, special cases are added for low Ruby versions to allow
installation of Nokogiri and Rack.